### PR TITLE
Upgrade Chart.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "chart.js": "3.0.0-alpha",
+    "chart.js": "3.0.0-alpha.2",
     "html-webpack-plugin": "4.5.0",
     "math-expression-evaluator": "1.2.22"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "chart.js": "3.0.0-alpha.2",
+    "chart.js": "3.0.0-beta.4",
     "html-webpack-plugin": "4.5.0",
     "math-expression-evaluator": "1.2.22"
   },

--- a/src/chart.js
+++ b/src/chart.js
@@ -1,4 +1,6 @@
-import Chart from 'chart.js'
+import { Chart, LineController, Line, Point, LinearScale, CategoryScale, Tooltip, Legend } from 'chart.js';
+
+Chart.register(LineController, Line, Point, LinearScale, CategoryScale, Tooltip, Legend);
 
 let chart
 const createChart = (ctx, { donneesMalades, donneesMorts, donneesRemis, donneesSains }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -592,10 +592,10 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chart.js@3.0.0-alpha.2:
-  version "3.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.0.0-alpha.2.tgz#445d8bbd727fc92815384a6a3d3de15477c7eefa"
-  integrity sha512-NMXuzoMorJPbMwnggXCXzqb82IHJ9fnQD2mNMTstGvZr9dhAo5/37l8TLIeemOow6uK4HMWu99hDXQno/2pkVg==
+chart.js@3.0.0-beta.4:
+  version "3.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.0.0-beta.4.tgz#c0a39b33f3412d84562bfeb605be913f79e6dd2e"
+  integrity sha512-aW5s5gFIZyIiTEZANC+DZKLLcVi5Sp3fo7EKKJau89mzPBOVjg3Rv9VOKmLOWx5zMFuDyBBAMylNrr3MSiO2Wg==
 
 chokidar@^2.1.8:
   version "2.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@kurkle/color@^0.1.6":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.1.9.tgz#949ea1494581b15576fca50d8486e5816fccfd27"
-  integrity sha512-K3Aul4Ct6O48yWw0/az5rqk2K76oNXXX3Su32Xkh4SfMFvPt0QEkq0Q6+3icE5S3U2c88WAuq3Vh1Iaz4aUH+w==
-
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -597,12 +592,10 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chart.js@3.0.0-alpha:
-  version "3.0.0-alpha"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.0.0-alpha.tgz#d82e3f7c882b8e321ad05bc1833f983b2b0b630b"
-  integrity sha512-9jbL1IsG9+1oq01GMKbeJ/257O46nVjQuYWEanpo0MuCr18cXMfkrzBTwdbl0VTOkIvWLJJcU5Cmhdc546k2bA==
-  dependencies:
-    "@kurkle/color" "^0.1.6"
+chart.js@3.0.0-alpha.2:
+  version "3.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.0.0-alpha.2.tgz#445d8bbd727fc92815384a6a3d3de15477c7eefa"
+  integrity sha512-NMXuzoMorJPbMwnggXCXzqb82IHJ9fnQD2mNMTstGvZr9dhAo5/37l8TLIeemOow6uK4HMWu99hDXQno/2pkVg==
 
 chokidar@^2.1.8:
   version "2.1.8"


### PR DESCRIPTION
New Webpack 5 tree shaking feature. Had to
```javascript
+ import { Chart, LineController, Line, Point, LinearScale, CategoryScale, Tooltip, Legend } from 'chart.js';
+
+ Chart.register(LineController, Line, Point, LinearScale, CategoryScale, Tooltip, Legend);
```

instead of
```javascript
import Chart from 'chart.js'
```